### PR TITLE
Enforce markdown format in template.md

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -1,18 +1,20 @@
+# RFC: \<RFC Title\>
+
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - Target Major Version: (1.x)
 - Reference Issues: (fill in existing related issues, if any)
 - Implementation PR: (leave this empty)
 
-# Summary
+## Summary
 
 Brief explanation of the feature.
 
-# Basic example
+## Basic example
 
 If the proposal involves a new or changed API, include a basic code example.
 Omit this section if it's not applicable.
 
-# Motivation
+## Motivation
 
 Why are we doing this? What use cases does it support? What is the expected
 outcome?
@@ -22,7 +24,7 @@ the motivation could be used to develop alternative solutions. In other words,
 enumerate the constraints you are trying to solve without coupling them too
 closely to the solution you have in mind.
 
-# Detailed design
+## Detailed design
 
 This is the bulk of the RFC. Explain the design in enough detail for somebody
 familiar with Vue to understand, and for somebody familiar with the
@@ -30,7 +32,7 @@ implementation to implement. This should get into specifics and corner-cases,
 and include examples of how the feature is used. Any new terminology should be
 defined here.
 
-# Drawbacks
+## Drawbacks
 
 Why should we *not* do this? Please consider:
 
@@ -42,16 +44,16 @@ Why should we *not* do this? Please consider:
 
 There are tradeoffs to choosing any path. Attempt to identify them here.
 
-# Alternatives
+## Alternatives
 
 What other designs have been considered? What is the impact of not doing this?
 
-# Adoption strategy
+## Adoption strategy
 
 If we implement this proposal, how will existing ComfyUI users and developers adopt it? Is
 this a breaking change? How will this affect other projects in the ComfyUI ecosystem?
 
-# Unresolved questions
+## Unresolved questions
 
 Optional, but suggested for first drafts. What parts of the design are still
 TBD?


### PR DESCRIPTION
This PR fixes the template to obey markdown rule

```
MD025/single-title/single-h1: Multiple top-level headings in the same documentmarkdownlint[MD025](https://github.com/DavidAnson/markdownlint/blob/v0.36.1/doc/md025.md)
```