### PR TITLE
Update readme to include RFC numbering instructions

### DIFF
--- a/.github/workflows/rfc-discussion.yml
+++ b/.github/workflows/rfc-discussion.yml
@@ -73,7 +73,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: ['rfc']
+              labels: ['rfc', 'pending']
             });
 
             // Lock PR comments

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ into ComfyUI.
 
     - Fork this repo.
 
-    - Create your proposal as `rfcs/0000-my-feature.md` (where "my-feature" is descriptive).
+    - Create your proposal as `rfcs/0000-my-feature.md` (where "my-feature" is descriptive). Don't assign an RFC number yet, that will be done when the PR is merged. Make sure to place the file in the `rfcs` directory.
 
     - Submit a pull request. A new thread in [Discussions](https://github.com/comfy-org/rfcs/discussions) will be made automatically.
 


### PR DESCRIPTION
Update README to instruct using `0000` numbering, as a number won't be assigned until the PR is merged. Same process as other RFC repos.