### PR TITLE
[fix] Prevent JavaScript syntax errors in sync workflow

### DIFF
--- a/.github/workflows/sync-rfc-discussion.yml
+++ b/.github/workflows/sync-rfc-discussion.yml
@@ -89,23 +89,36 @@ jobs:
       - name: Update Discussion Content
         if: steps.find-discussion.outputs.discussion_id && steps.changed-files.outputs.filename
         uses: actions/github-script@v7
+        env:
+          DISCUSSION_ID: ${{ steps.find-discussion.outputs.discussion_id }}
+          RFC_CONTENT: ${{ steps.get-rfc-content.outputs.content }}
+          MD_FILE: ${{ steps.changed-files.outputs.filename }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO_NAME: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          UPDATED_AT: ${{ github.event.pull_request.updated_at }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.html_url }}
         with:
           script: |
-            const discussionId = '${{ steps.find-discussion.outputs.discussion_id }}';
-            const rfcContent = '${{ steps.get-rfc-content.outputs.content }}';
-            const mdFile = '${{ steps.changed-files.outputs.filename }}';
+            const discussionId = process.env.DISCUSSION_ID;
+            const rfcContent = process.env.RFC_CONTENT;
+            const mdFile = process.env.MD_FILE;
             
             // Build the body content parts
-            const title = `# RFC Discussion: ${{ github.event.pull_request.title }}`;
-            const author = `**Author:** @${{ github.event.pull_request.user.login }} | **Status:** 🟡 Under Review`;
+            const title = `# RFC Discussion: ${process.env.PR_TITLE}`;
+            const author = `**Author:** @${process.env.PR_AUTHOR} | **Status:** 🟡 Under Review`;
             const links = `## 📋 Quick Links
-            - 🔧 [Source PR #${{ github.event.pull_request.number }}](${{ github.event.pull_request.html_url }})
-            - 📝 [View Changes](${{ github.event.pull_request.html_url }}/files)
-            - 📖 [Rendered Proposal](https://github.com/${{ github.repository }}/blob/${{ github.event.pull_request.head.ref }}/${mdFile})`;
+            - 🔧 [Source PR #${process.env.PR_NUMBER}](${process.env.PR_URL})
+            - 📝 [View Changes](${process.env.PR_URL}/files)
+            - 📖 [Rendered Proposal](https://github.com/${process.env.REPO_NAME}/blob/${process.env.HEAD_REF}/${mdFile})`;
             
             const proposalHeader = `## 📄 Current Proposal`;
-            const metadata = `> **Last Updated:** ${{ github.event.pull_request.updated_at }}
-            > **Commit:** [\`${{ github.event.pull_request.head.sha }}\`](${{ github.event.pull_request.head.repo.html_url }}/commit/${{ github.event.pull_request.head.sha }})`;
+            const metadata = `> **Last Updated:** ${process.env.UPDATED_AT}
+            > **Commit:** [\`${process.env.HEAD_SHA}\`](${process.env.HEAD_REPO_URL}/commit/${process.env.HEAD_SHA})`;
             
             const guidelines = `**💬 Discussion Guidelines:** Share feedback, concerns, and suggestions below. Use reply threads to keep conversations organized.`;
             


### PR DESCRIPTION
Fixes syntax errors in the RFC discussion sync workflow that occur when PR titles or RFC content contain special characters like brackets, quotes, or apostrophes.

**Problem:** The sync workflow was embedding GitHub Actions expressions directly in JavaScript template literals, causing syntax errors when content contained special characters.

**Solution:** Use environment variables to pass all dynamic content, avoiding template literal conflicts.

This enables the sync workflow to handle any RFC content safely, including edge cases like:
- Square brackets in PR titles: `[feat] Add new feature`
- Apostrophes in content: `GitHub's API`
- Any other special JavaScript characters

**Testing:** After merge, the existing test PR should successfully sync discussion content on future commits.